### PR TITLE
Add other Lua rule to handle change in newer LuaJIT

### DIFF
--- a/rules/lua_rules.json
+++ b/rules/lua_rules.json
@@ -33,6 +33,7 @@
 	"FrameMan:Draw(": "PrimitiveMan:Draw(",
 	":IsPlaying(": ":IsBeingPlayed(",
 	"math.mod(": "math.fmod(",
+	"string.gfind(": "string.gmatch(",
 	":ReloadFirearm(": ":ReloadFirearms(",
 	":KillAllActors(": ":KillAllEnemyActors(",
 	".TotalWoundCount": ".WoundCount",


### PR DESCRIPTION
Adds a rule to handle the other compat name removed in LuaJIT 2.1 related to Lua 5.0

https://github.com/LuaJIT/LuaJIT/pull/302
https://github.com/LuaJIT/LuaJIT/commit/de5568e0eaf22d2c7d58c2cbd9060460abc4ff2f


I wouldn't surprised if there are literally 0 mods in the wild (or even existence for that matter) that call/use `string.gfind` but there's no harm in havin all bases covered and whatnot especially since someone *could* technically at any point go and make a mod for the original Cortex Command that uses the old `string.gfind` name and ends up causing a case where the mod convertor fails to make a mod compatible with CCCP as a result.